### PR TITLE
Used 2to3 and some additional changes to make scripts run under Python3

### DIFF
--- a/releng/__init__.py
+++ b/releng/__init__.py
@@ -12,7 +12,7 @@ For testing, the package can also be executed as a command-line module.
 
 # Expose the JobType enum to make it simpler to import just the releng module
 # and call run_build().
-from common import JobType, Project
+from .common import JobType, Project
 
 def run_build(build, job_type, opts, project=Project.GROMACS):
     """Main entry point for Jenkins builds.
@@ -38,8 +38,8 @@ def run_build(build, job_type, opts, project=Project.GROMACS):
             Build scripts not intended for such builds may simply ignore most
             of the parameters that can be influenced by these options.
     """
-    from context import BuildContext
-    from factory import ContextFactory
+    from .context import BuildContext
+    from .factory import ContextFactory
     # Please ensure that __main__.py stays in sync.
     factory = ContextFactory(default_project=project)
     with factory.status_reporter:
@@ -51,8 +51,8 @@ def read_build_script_config(script_name):
     Args:
         script_name (str): Name of the build script (see run_build()).
     """
-    from context import BuildContext
-    from factory import ContextFactory
+    from .context import BuildContext
+    from .factory import ContextFactory
     factory = ContextFactory()
     with factory.status_reporter as status:
         config = BuildContext._read_build_script_config(factory, script_name)
@@ -70,8 +70,8 @@ def prepare_multi_configuration_build(configfile):
             Names without directory separators are interpreted as
             :file:`gromacs/admin/builds/{configfile}.txt`.
     """
-    from factory import ContextFactory
-    from matrixbuild import prepare_build_matrix
+    from .factory import ContextFactory
+    from .matrixbuild import prepare_build_matrix
     factory = ContextFactory()
     with factory.status_reporter as status:
         status.return_value = prepare_build_matrix(factory, configfile)
@@ -88,8 +88,8 @@ def process_multi_configuration_build_results(inputfile):
     Args:
         inputfile (str): File to read the input from, relative to working dir.
     """
-    from factory import ContextFactory
-    from matrixbuild import process_matrix_results
+    from .factory import ContextFactory
+    from .matrixbuild import process_matrix_results
     factory = ContextFactory()
     with factory.status_reporter as status:
         status.return_value = process_matrix_results(factory, inputfile)
@@ -100,8 +100,8 @@ def get_actions_from_triggering_comment():
     Parses the comment that triggered an on-demand build and returns a
     structure that tells the workflow build what it needs to do.
     """
-    from factory import ContextFactory
-    from ondemand import get_actions_from_triggering_comment
+    from .factory import ContextFactory
+    from .ondemand import get_actions_from_triggering_comment
     factory = ContextFactory()
     with factory.status_reporter as status:
         status.return_value = get_actions_from_triggering_comment(factory)
@@ -119,8 +119,8 @@ def do_ondemand_post_build(inputfile):
     Args:
         inputfile (str): File to read the input from, relative to working dir.
     """
-    from factory import ContextFactory
-    from ondemand import do_post_build
+    from .factory import ContextFactory
+    from .ondemand import do_post_build
     factory = ContextFactory()
     with factory.status_reporter as status:
         status.return_value = do_post_build(factory, inputfile)
@@ -131,7 +131,7 @@ def get_build_revisions():
     Returns a structure that provides a list of projects and their revisions
     used in this build.
     """
-    from factory import ContextFactory
+    from .factory import ContextFactory
     factory = ContextFactory()
     with factory.status_reporter as status:
         status.return_value = factory.projects.get_build_revisions()
@@ -142,8 +142,8 @@ def read_source_version_info():
     Returns a structure that provides version information from the source
     repository.
     """
-    from context import BuildContext
-    from factory import ContextFactory
+    from .context import BuildContext
+    from .factory import ContextFactory
     factory = ContextFactory()
     with factory.status_reporter as status:
         context = BuildContext._run_build(factory, 'get-version-info', JobType.GERRIT, None)

--- a/releng/__main__.py
+++ b/releng/__main__.py
@@ -11,10 +11,10 @@ instead.
 import argparse
 import os
 
-from common import Project
-from context import BuildContext
-from factory import ContextFactory
-import matrixbuild
+from .common import Project
+from .context import BuildContext
+from .factory import ContextFactory
+from . import matrixbuild
 
 def run_build(args, factory):
     BuildContext._run_build(factory, args.script, args.job_type, args.opts)
@@ -87,7 +87,7 @@ env.update({
 # Please ensure that run_build() in __init__.py stays in sync.
 factory = ContextFactory(default_project=project, system=args.system, env=env)
 if not args.run:
-    from executor import DryRunExecutor
+    from .executor import DryRunExecutor
     factory.init_executor(cls=DryRunExecutor)
 factory.init_gerrit_integration(user=args.user)
 with factory.status_reporter as status:

--- a/releng/agents.py
+++ b/releng/agents.py
@@ -1,7 +1,7 @@
 """
 Information about Jenkins build agents
 """
-from common import ConfigurationError
+from .common import ConfigurationError
 
 BS_MAC = 'bs_mac'
 BS_MIC = 'bs_mic'
@@ -261,7 +261,7 @@ def pick_host(labels, opts):
     if labels.issubset(_HOST_LABELS[DOCKER_DEFAULT]):
         return DOCKER_DEFAULT
     possible_hosts = []
-    for host, host_labels in _HOST_LABELS.iteritems():
+    for host, host_labels in _HOST_LABELS.items():
         if labels.issubset(host_labels):
             possible_hosts.append(host)
     if not possible_hosts:

--- a/releng/cmake.py
+++ b/releng/cmake.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import xml.etree.ElementTree as ET
 
-from common import BuildError, ConfigurationError
+from .common import BuildError, ConfigurationError
 
 def read_cmake_variable_file(executor, path):
     """Reads a file with CMake variable declarations (set commands).

--- a/releng/common.py
+++ b/releng/common.py
@@ -76,7 +76,7 @@ class Enum(object):
             attrs[attr_name] = string
             values.append(attrs[attr_name])
         attrs.update(kwargs)
-        values.extend(kwargs.itervalues())
+        values.extend(iter(kwargs.values()))
         attrs['_values'] = tuple(values)
         return type(name, (Enum,), attrs)
 

--- a/releng/context.py
+++ b/releng/context.py
@@ -8,12 +8,12 @@ import re
 import shutil
 import subprocess
 
-from common import BuildError, CommandError, ConfigurationError
-from common import JobType, Project
-from options import BuildConfig, process_build_options, select_build_hosts
-from script import BuildScript, BuildScriptSettings
-import cmake
-import utils
+from .common import BuildError, CommandError, ConfigurationError
+from .common import JobType, Project
+from .options import BuildConfig, process_build_options, select_build_hosts
+from .script import BuildScript, BuildScriptSettings
+from . import cmake
+from . import utils
 
 class BuildContext(object):
     """Top-level interface for build scripts to the releng package.
@@ -127,7 +127,7 @@ class BuildContext(object):
             cmake_args.extend(['-G', self.env.cmake_generator])
         cmake_args.extend(
                 ['-D{0}={1}'.format(key, value)
-                    for key, value in sorted(options.iteritems())
+                    for key, value in sorted(options.items())
                     if value is not None])
         self.run_cmd([self.env.cmake_command, '--version'])
         self.run_cmd(cmake_args, failure_message='CMake configuration failed')

--- a/releng/environment.py
+++ b/releng/environment.py
@@ -7,10 +7,10 @@ agent environment, such as paths to various executables.
 
 import os
 
-from common import ConfigurationError
-from common import Compiler,System
-import cmake
-import agents
+from .common import ConfigurationError
+from .common import Compiler,System
+from . import cmake
+from . import agents
 import re
 
 # TODO: Check that the paths returned/used actually exists and raise nice

--- a/releng/executor.py
+++ b/releng/executor.py
@@ -11,7 +11,6 @@ object to allow the above replacements to work as intended.  For now, this is
 not used throughout the scripts, but its use and scope will be extended with
 expanding unit tests.
 """
-from __future__ import print_function
 
 from distutils.spawn import find_executable
 import os
@@ -21,8 +20,8 @@ import shutil
 import subprocess
 import sys
 
-from common import AbortError, CommandError, System
-import utils
+from .common import AbortError, CommandError, System
+from . import utils
 
 def _read_file(path, binary):
     if binary:

--- a/releng/factory.py
+++ b/releng/factory.py
@@ -5,11 +5,11 @@ Declares a factory class for wiring together all the other releng classes.
 import os
 import platform
 
-from common import Project, System
-from context import BuildContext
-from executor import CommandRunner, CurrentDirectoryTracker, Executor
-from integration import GerritIntegration, JenkinsIntegration, ProjectsManager, StatusReporter
-from workspace import Workspace
+from .common import Project, System
+from .context import BuildContext
+from .executor import CommandRunner, CurrentDirectoryTracker, Executor
+from .integration import GerritIntegration, JenkinsIntegration, ProjectsManager, StatusReporter
+from .workspace import Workspace
 
 class ContextFactory(object):
 

--- a/releng/matrixbuild.py
+++ b/releng/matrixbuild.py
@@ -10,9 +10,9 @@ import os.path
 import pipes
 import shlex
 
-from common import BuildError, ConfigurationError, Project
-from options import BuildConfig, select_build_hosts
-import agents
+from .common import BuildError, ConfigurationError, Project
+from .options import BuildConfig, select_build_hosts
+from . import agents
 
 def prepare_build_matrix(factory, configfile):
     projects = factory.projects

--- a/releng/ondemand.py
+++ b/releng/ondemand.py
@@ -5,10 +5,10 @@ import json
 import os.path
 import re
 
-from common import BuildError, JobType, Project
-from integration import RefSpec
-from matrixbuild import get_matrix_info
-from script import BuildScript
+from .common import BuildError, JobType, Project
+from .integration import RefSpec
+from .matrixbuild import get_matrix_info
+from .script import BuildScript
 
 def get_actions_from_triggering_comment(factory):
     request = factory.gerrit.get_triggering_comment()
@@ -204,7 +204,7 @@ def do_post_build(factory, inputfile):
         reason = reasons[0]
     elif build_messages:
         reason = '\n'.join(build_messages)
-    if data.has_key('gerrit_info') and data['gerrit_info']:
+    if 'gerrit_info' in data and data['gerrit_info']:
         gerrit_info = data['gerrit_info']
         change = gerrit_info['change']
         patchset = gerrit_info['patchset']
@@ -216,7 +216,7 @@ def _get_reasons(factory, data):
     return [_get_reason(factory, x) for x in builds]
 
 def _get_reason(factory, build):
-    if build.has_key('reason') and build['reason']:
+    if 'reason' in build and build['reason']:
         return build['reason'].rstrip()
     return None
 
@@ -237,12 +237,12 @@ def _get_title(build):
     return _append_desc(title, build)
 
 def _get_url(build):
-    if build.has_key('url') and build['url']:
+    if 'url' in build and build['url']:
         return build['url']
     return None
 
 def _append_desc(text, build):
-    if text and build.has_key('desc') and build['desc']:
+    if text and 'desc' in build and build['desc']:
         text += ' ({0})'.format(build['desc'])
     return text
 

--- a/releng/options.py
+++ b/releng/options.py
@@ -10,11 +10,11 @@ code is internal to releng.
 import re
 import shlex
 
-from common import to_python_identifier
-from common import ConfigurationError
-from common import BuildType, FftLibrary, Simd, Gpuhw
-from environment import BuildEnvironment
-import agents
+from .common import to_python_identifier
+from .common import ConfigurationError
+from .common import BuildType, FftLibrary, Simd, Gpuhw
+from .environment import BuildEnvironment
+from . import agents
 
 class BuildConfig(object):
     def __init__(self, opts, host=None):
@@ -386,7 +386,7 @@ def _define_handlers(e, extra_options):
         handlers.append(_VersionOptionHandler('opencl', e._init_opencl, label=OPT))
 
     if extra_options:
-        for name, builder in extra_options.iteritems():
+        for name, builder in extra_options.items():
             new_handler = builder(name)
             existing_handlers = [x for x in handlers if x.name == name]
             assert len(existing_handlers) <= 1
@@ -427,7 +427,7 @@ def process_build_options(factory, opts, script_settings):
 
 def _remove_host_option(opts):
     """Removes options that specify the execution host."""
-    return list(filter(lambda x: not x.lower().startswith(('host=', 'label=')), opts))
+    return list([x for x in opts if not x.lower().startswith(('host=', 'label='))])
 
 def select_build_hosts(factory, configs):
     """Selects build host for each configuration.

--- a/releng/script.py
+++ b/releng/script.py
@@ -5,13 +5,14 @@ This module is only used internally within the releng package.
 """
 
 import os.path
+import collections
 
-from common import BuildError, ConfigurationError
-from common import Enum
-from common import BuildType, Compiler, FftLibrary, JobType, Project, Simd, Gpuhw, System
-from integration import ParameterTypes
-from options import OptionTypes
-import utils
+from .common import BuildError, ConfigurationError
+from .common import Enum
+from .common import BuildType, Compiler, FftLibrary, JobType, Project, Simd, Gpuhw, System
+from .integration import ParameterTypes
+from .options import OptionTypes
+from . import utils
 
 class BuildScriptSettings(object):
     """
@@ -85,7 +86,7 @@ class BuildScript(object):
         code = compile(source, path, 'exec')
         exec(code, build_globals)
         do_build = build_globals.get('do_build', None)
-        if do_build is None or not callable(do_build):
+        if do_build is None or not isinstance(do_build, collections.Callable):
             raise ConfigurationError('build script does not define do_build(): ' + path)
         self._do_build = do_build
         self.settings = BuildScriptSettings()

--- a/releng/test/test_context.py
+++ b/releng/test/test_context.py
@@ -1,8 +1,6 @@
 import os.path
 import unittest
-# With Python 2.7, this needs to be separately installed.
-# With Python 3.3 and up, this should change to unittest.mock.
-import mock
+from unittest import mock
 
 from releng.common import JobType
 from releng.context import BuildContext

--- a/releng/test/test_integration.py
+++ b/releng/test/test_integration.py
@@ -1,9 +1,7 @@
 import base64
 import os.path
 import unittest
-# With Python 2.7, this needs to be separately installed.
-# With Python 3.3 and up, this should change to unittest.mock.
-import mock
+from unittest import mock
 
 from releng.common import AbortError, BuildError, Project
 from releng.integration import BuildParameters, ParameterTypes, RefSpec

--- a/releng/test/test_matrixbuild.py
+++ b/releng/test/test_matrixbuild.py
@@ -1,8 +1,6 @@
 import os.path
 import unittest
-# With Python 2.7, this needs to be separately installed.
-# With Python 3.3 and up, this should change to unittest.mock.
-import mock
+from unittest import mock
 
 from releng.common import Project
 from releng.matrixbuild import prepare_build_matrix

--- a/releng/test/test_ondemand.py
+++ b/releng/test/test_ondemand.py
@@ -1,9 +1,7 @@
 import base64
 import os.path
 import unittest
-# With Python 2.7, this needs to be separately installed.
-# With Python 3.3 and up, this should change to unittest.mock.
-import mock
+from unittest import mock
 
 from releng.common import Project
 from releng.ondemand import get_actions_from_triggering_comment

--- a/releng/test/test_script.py
+++ b/releng/test/test_script.py
@@ -1,8 +1,6 @@
 import os.path
 import unittest
-# With Python 2.7, this needs to be separately installed.
-# With Python 3.3 and up, this should change to unittest.mock.
-import mock
+from unittest import mock
 
 from releng.common import Project
 from releng.script import BuildScript

--- a/releng/test/utils.py
+++ b/releng/test/utils.py
@@ -1,11 +1,9 @@
 import json
 import os.path
-from StringIO import StringIO
+from io import StringIO
 import textwrap
-import urlparse
-# With Python 2.7, this needs to be separately installed.
-# With Python 3.3 and up, this should change to unittest.mock.
-import mock
+import urllib.parse
+from unittest import mock
 
 from releng.common import CommandError, Project
 from releng.executor import Executor
@@ -62,7 +60,7 @@ class RepositoryTestState(object):
 
     @property
     def projects(self):
-        return self._commits.keys()
+        return list(self._commits.keys())
 
     def has_project(self, project):
         return project in self._commits
@@ -74,9 +72,9 @@ class RepositoryTestState(object):
         if project:
             return self._commits[project]
         if sha1:
-            return filter(lambda x: x.sha1 == sha1, self._commits.itervalues())[0]
+            return filter(lambda x: x.sha1 == sha1, self._commits.values())[0]
         if change_number:
-            return filter(lambda x: x.change_number == change_number, self._commits.itervalues())[0]
+            return filter(lambda x: x.change_number == change_number, self._commits.values())[0]
 
     @property
     def expected_build_revisions(self):
@@ -151,7 +149,7 @@ class TestHelper(object):
                 raise CommandError('commit not found: ' + cmd[4])
             return '{0} {1}\n'.format(commit.sha1, commit.title)
         elif cmd[:2] == ['git', 'ls-remote']:
-            git_url = urlparse.urlsplit(cmd[2])
+            git_url = urllib.parse.urlsplit(cmd[2])
             project = Project.parse(os.path.splitext(git_url.path[1:])[0])
             commit = self._commits.find_commit(project, refspec=cmd[3])
             return '{0} {1}\n'.format(commit.sha1, commit.refspec)

--- a/releng/utils.py
+++ b/releng/utils.py
@@ -38,5 +38,5 @@ def write_property_file(executor, path, values):
         path (str): Path to the file to write.
         values (Dict): Dictionary of key/value pairs to write.
     """
-    contents = ''.join(['{0} = {1}\n'.format(key, value) for key, value in values.iteritems() if value is not None])
+    contents = ''.join(['{0} = {1}\n'.format(key, value) for key, value in values.items() if value is not None])
     executor.write_file(path, contents)

--- a/releng/workspace.py
+++ b/releng/workspace.py
@@ -4,13 +4,12 @@ Build workspace handling
 This module should contain most (if not all) raw file manipulation
 commands related to setting up and inspecting the workspace.
 """
-from __future__ import print_function
 
 import os.path
 import tarfile
 
-from common import BuildError, CommandError, ConfigurationError
-from common import Project
+from .common import BuildError, CommandError, ConfigurationError
+from .common import Project
 
 class CheckedOutProject(object):
     """Information about a checked-out project.


### PR DESCRIPTION
I used this to build documentation with Python 3 (see https://gerrit.gromacs.org/c/6621/). This change does not maintain python2 compatibility. While we're aiming at moving to Py3 for the next release, it might take a while before that is fully implemented. I see three options to handle this in the transition period:

1. Put python3 releng in a separate branch, having both the py3 and py2 versions available for now, merge into master when py2 support is not needed anymore.
2. Introduce a (temporary) dependency on six, making a py2/py3 compatible version easy to code (basically just using futurize and maybe some manual tweeks).
3. Write a fully py2/py3 compatible version of releng without introducing new dependencies. This is doable, but would need more work and testing.

I assume this mostly depends how long we want / need to keep releng compatible with py2, and how often we make changes (which, in case of option 1., we'd need to duplicate).